### PR TITLE
trickle ice

### DIFF
--- a/cmd/ww/pipe.go
+++ b/cmd/ww/pipe.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"os"
 )
 
@@ -12,7 +11,7 @@ func pipe(args ...string) {
 	set := flag.NewFlagSet(args[0], flag.ExitOnError)
 	set.Usage = func() {
 		fmt.Fprintf(set.Output(), "netcat-like pipe\n\n")
-		fmt.Fprintf(set.Output(), "usage: %s %s [code]\n\n", os.Args[0],  args[0])
+		fmt.Fprintf(set.Output(), "usage: %s %s [code]\n\n", os.Args[0], args[0])
 		fmt.Fprintf(set.Output(), "flags:\n")
 		set.PrintDefaults()
 	}
@@ -30,7 +29,7 @@ func pipe(args ...string) {
 	go func() {
 		_, err := io.CopyBuffer(os.Stdout, c, make([]byte, msgChunkSize))
 		if err != nil {
-			log.Printf("could not write to stdout: %v", err)
+			fatalf("could not write to stdout: %v", err)
 		}
 		done <- struct{}{}
 	}()
@@ -38,7 +37,7 @@ func pipe(args ...string) {
 	go func() {
 		_, err := io.CopyBuffer(c, os.Stdin, make([]byte, msgChunkSize))
 		if err != nil {
-			log.Printf("could not write to channel: %v", err)
+			fatalf("could not write to channel: %v", err)
 		}
 		done <- struct{}{}
 	}()

--- a/cmd/ww/server.go
+++ b/cmd/ww/server.go
@@ -29,7 +29,8 @@ const slotTimeout = 30 * time.Minute
 // to upgrade.
 const protocolVersion = "3"
 
-const importMeta = `
+const importMeta = `<!doctype html>
+<meta charset=utf-8>
 <meta name="go-import" content="webwormhole.io git https://github.com/saljam/webwormhole">
 <meta http-equiv="refresh" content="0;URL='https://github.com/saljam/webwormhole'">
 `

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	filippo.io/cpace v0.0.0-20200329174001-6ff507385bae
 	github.com/golang/protobuf v1.3.5 // indirect
+	github.com/gorilla/websocket v1.4.2
 	github.com/lucas-clemente/quic-go v0.15.2 // indirect
 	github.com/pion/rtp v1.4.0 // indirect
 	github.com/pion/sdp/v2 v2.3.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module webwormhole.io
 go 1.13
 
 require (
-	filippo.io/cpace v0.0.0-20200329174001-6ff507385bae
+	filippo.io/cpace v0.0.0-20200503185815-340c58da85ed
 	github.com/golang/protobuf v1.3.5 // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/lucas-clemente/quic-go v0.15.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/gtank/ristretto255 v0.1.2 h1:JEqUCPA1NvLq5DwYtuzigd7ss8fwbYay9fi4/5uMzcc=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 filippo.io/cpace v0.0.0-20200329174001-6ff507385bae h1:65bv8FFj5QnVm/PiZRT4PyGQ0XmIsnS6OZrNO6IfdGo=
 filippo.io/cpace v0.0.0-20200329174001-6ff507385bae/go.mod h1:b8UFwXF0HGYD8OWBGJEPwu3IMDHqTpzCtGFtY2xRwTU=
+filippo.io/cpace v0.0.0-20200503185815-340c58da85ed h1:+6tV4gCvAW6BbCHa+yrkoo4xlwIb37KKvyBWCFLAHeg=
+filippo.io/cpace v0.0.0-20200503185815-340c58da85ed/go.mod h1:b8UFwXF0HGYD8OWBGJEPwu3IMDHqTpzCtGFtY2xRwTU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/alangpierce/go-forceexport v0.0.0-20160317203124-8f1d6941cd75 h1:3ILjVyslFbc4jl1w5TWuvvslFD/nDfR2H8tVaMVLrEY=

--- a/web/dial.js
+++ b/web/dial.js
@@ -46,7 +46,6 @@ export let newwormhole = async (pc) => {
 			ws.send(msgB);
 			pc.onicecandidate=e=>{
 				if (e.candidate) {
-					e.candidate.type = "candidate";
 					ws.send(util.seal(key, JSON.stringify(e.candidate)));
 				}
 			}
@@ -124,7 +123,6 @@ export let dial = async (pc, code) => {
 			console.log("generated key");
 			pc.onicecandidate=e=>{
 				if (e.candidate) {
-					e.candidate.type = "candidate";
 					ws.send(util.seal(key, JSON.stringify(e.candidate)));
 				}
 			}

--- a/web/dial.js
+++ b/web/dial.js
@@ -1,9 +1,9 @@
-const signalserver = "/"; // relative URL, no CORS.
+import { genpassword } from './wordlist.js';
 
-// TODO something nicer than this global?
-// https://github.com/golang/go/issues/25612
+const signalserver = ((location.protocol==="https:")?"wss://":"ws://")+location.host+"/s/";
+
 export let goready = new Promise(async r => {
-	if (!WebAssembly.instantiateStreaming) { // polyfill for Safari.
+	if (!WebAssembly.instantiateStreaming) { // for Safari.
 		WebAssembly.instantiateStreaming = async (resp, importObject) => {
 			const source = await (await resp).arrayBuffer();
 			return await WebAssembly.instantiate(source, importObject);
@@ -16,89 +16,168 @@ export let goready = new Promise(async r => {
 });
 
 // newwormhole creates wormhole, the A side.
-export let newwormhole = async (pc, pass) => {
-	let candidates = collectcandidates(pc);
-	let msgA = util.start(pass)
-	if (msgA == null) {
-		throw "couldn't generate A's PAKE message";
-	}
-	let response = await fetch(signalserver, {
-		method: 'POST',
-		body: JSON.stringify({msgA})
-	})
-	if (response.status !== 200) {
-		throw "couldn't reach signalling server";
-	}
-	let slot = response.headers.get("location").slice(1); // remove leading slash
-
-	let cont = async () => {
-		let msg = await response.json();
-		let key = util.finish(msg.msgB);
-		if (key == null) {
-			throw "couldn't generate key";
+export let newwormhole = async (pc) => {
+	let ws = new WebSocket(signalserver);
+	let key, slot, pass;
+	let slotC, connC;
+	let slotP = new Promise((resolve, reject) => {
+		slotC = {resolve, reject};
+	});
+	let connP = new Promise((resolve, reject) => {
+		connC = {resolve, reject};
+	});
+	ws.onmessage = async m => {
+		if (!slot) {
+			slot = m.data;
+			pass = genpassword(2);
+			console.log("assigned slot:", slot);
+			slotC.resolve(slot + "-" + pass);
+			return
 		}
-		let jsonoffer = util.open(key, msg.offer)
-		if (jsonoffer == null) {
-			// Auth failed.
-			await fetch(signalserver+slot, {
-				method: 'DELETE',
-				body: JSON.stringify({answer:util.seal(key,"bye")}),
-				headers: {'If-Match': response.headers.get('ETag')}
-			});
-			throw "bad key";
+		if (!key) {
+			console.log("got pake message a:", m.data);
+			let msgB;
+			[key, msgB] = util.exchange(pass, m.data);
+			console.log("message b:", msgB);
+			if (key == null) {
+				connC.reject("couldn't generate key")
+			}
+			console.log("generated key");
+			ws.send(msgB);
+			pc.onicecandidate=e=>{
+				if (e.candidate) {
+					e.candidate.type = "candidate";
+					ws.send(util.seal(key, JSON.stringify(e.candidate)));
+				}
+			}
+			await pc.setLocalDescription(await pc.createOffer());
+			ws.send(util.seal(key, JSON.stringify(pc.localDescription)));
+			return
 		}
-		let offer = JSON.parse(jsonoffer);
-		await pc.setRemoteDescription(new RTCSessionDescription(offer));
-		await pc.setLocalDescription(await pc.createAnswer());
-		await candidates;
-		await fetch(signalserver+slot, {
-			method: 'DELETE',
-			body: JSON.stringify({answer:util.seal(key, JSON.stringify(pc.localDescription))}),
-			headers: {'If-Match': response.headers.get('ETag')}
-		});
+		let jsonmsg = util.open(key, m.data);
+		if (jsonmsg === null) {
+			// Auth failed. Send something so B knows.
+			ws.send(util.seal(key, "bye"));
+			ws.close();
+			connC.reject("bad key")
+			return
+		}
+		let msg = JSON.parse(jsonmsg);
+		if (msg.type === "offer") {
+			await pc.setRemoteDescription(new RTCSessionDescription(msg));
+			await pc.setLocalDescription(await pc.createAnswer());
+			ws.send(util.seal(key, JSON.stringify(pc.localDescription)))
+			return
+		}
+		if (msg.type === "answer") {
+			await pc.setRemoteDescription(new RTCSessionDescription(msg));
+			return
+		}
+		if (msg.candidate) {
+			pc.addIceCandidate(new RTCIceCandidate(msg));
+			return
+		}
+		console.log("unknown message type", msg)
+	}
+	ws.onopen = e => {
+		console.log("websocket session established")
+	}
+	ws.onerror = e => {
+		connC.reject("couldn't connect to signalling server")
+		console.log("websocket session error", e)
+	}
+	ws.onclose = e => {
+		if (e.code === 404) {
+			connC.reject("no such slot")
+		} else if (e.code === 500) {
+			connC.reject("couldn't get slot")
+		} else if (e.code === 408) {
+			connC.reject("timed out")
+		} else {
+			console.log("websocket session closed", e)
+		}
 	}
 
-	return [slot, cont()];
+	return [await slotP, connP];
 }
 
 // dial joins a wormhole, the B side.
-export let dial = async (pc, slot, pass) => {
-	let candidates = collectcandidates(pc);
-	let response = await fetch(signalserver+slot)
-	if (response.status !== 200) {
-		throw "no such slot";
-	}
-	let msg = await response.json();
-	let [key, msgB] = util.exchange(pass, msg.msgA);
-	if (key == null) {
-		throw "couldn't generate key";
-	}
-	await pc.setLocalDescription(await pc.createOffer())
-	await candidates;
-	response = await fetch(signalserver+slot, {
-		method: 'PUT',
-		body: JSON.stringify({
-			msgB,
-			offer:util.seal(key, JSON.stringify(pc.localDescription)) // also probably ok
-		}),
-		headers: {'If-Match': response.headers.get('ETag')}
-	});
-	msg = await response.json();
-	let jsonanswer = util.open(key, msg.answer)
-	if (jsonanswer == null) {
-		throw "bad key";
-	}
-	let answer = JSON.parse(jsonanswer);
-	await pc.setRemoteDescription(new RTCSessionDescription(answer));
-}
+export let dial = async (pc, code) => {
+	let [slot, ...passparts] = code.split("-");
+	let pass = passparts.join("-");
 
-// collectcandidates returns a promise that's resolved when pc has gathered all its candidates
-let collectcandidates = pc => {
-	return new Promise(r=>{
-		pc.onicecandidate=e=>{
-			if (e.candidate === null) {
-				r();
-			}
-		}
+	console.log("dialling slot:", slot);
+
+	let ws = new WebSocket(signalserver+slot);
+	let key;
+	let connC;
+	let connP = new Promise((resolve, reject) => {
+		connC = {resolve, reject};
 	});
+	ws.onmessage = async m => {
+		if (!key) {
+			console.log("got pake message b:", m.data);
+			key = util.finish(m.data);
+			if (key == null) {
+				connC.reject("couldn't generate key")
+			}
+			console.log("generated key");
+			pc.onicecandidate=e=>{
+				if (e.candidate) {
+					e.candidate.type = "candidate";
+					ws.send(util.seal(key, JSON.stringify(e.candidate)));
+				}
+			}
+			return
+		}
+		let jmsg = util.open(key, m.data);
+		if (jmsg == null) {
+			// Auth failed. Send something so A knows.
+			ws.send(util.seal(key, "bye"));
+			ws.close();
+			connC.reject("bad key")
+			return
+		}
+		let msg = JSON.parse(jmsg);
+		if (msg.type === "offer") {
+			await pc.setRemoteDescription(new RTCSessionDescription(msg));
+			await pc.setLocalDescription(await pc.createAnswer());
+			ws.send(util.seal(key, JSON.stringify(pc.localDescription)))
+			return
+		}
+		if (msg.type === "answer") {
+			await pc.setRemoteDescription(new RTCSessionDescription(msg));
+			return
+		}
+		if (msg.candidate) {
+			pc.addIceCandidate(new RTCIceCandidate(msg));
+			return
+		}
+		console.log("unknown message type", msg)
+	}
+	ws.onopen = async e => {
+		console.log("websocket opened")
+		let msgA = util.start(pass)
+		if (msgA == null) {
+			connC.reject("couldn't generate A's PAKE message")
+		}
+		console.log("message a:", msgA);
+		ws.send(msgA);
+	}
+	ws.onerror = e => {
+		connC.reject("couldn't connect to signalling server")
+		console.log("websocket session error", e)
+	}
+	ws.onclose = e => {
+		if (e.code === 404) {
+			connC.reject("no such slot")
+		} else if (e.code === 500) {
+			connC.reject("couldn't get slot")
+		} else if (e.code === 408) {
+			connC.reject("timed out")
+		} else {
+			console.log("websocket session closed", e)
+		}
+	}
+	return await connP
 }

--- a/web/main.js
+++ b/web/main.js
@@ -1,5 +1,4 @@
 import { goready, newwormhole, dial } from './dial.js';
-import { genpassword } from './wordlist.js';
 
 // TODO multiple streams.
 let receiving;
@@ -167,39 +166,29 @@ let connect = async e => {
 		if (document.getElementById("magiccode").value === "") {
 			dialling();
 			document.getElementById("info").innerHTML = "WAITING FOR THE OTHER SIDE - SHARE CODE OR URL";
-
-			// TODO move this logic to wormhole package.
-			let pass = genpassword(2);
-			let [slot, c] = await newwormhole(pc, pass);
-			let code = slot + "-" + pass;
-
-			console.log ("assigned slot", slot, "pass", pass);
+			let [code, finish] = await newwormhole(pc);
 			document.getElementById("magiccode").value = code;
 			location.hash = code;
-
 			let qr = util.qrencode(location.href);
 			if (qr === null) {
 				document.getElementById("qr").src = "";
 			} else {
 				document.getElementById("qr").src = URL.createObjectURL(new Blob([qr]));
 			}
-
-			await c;
+			await finish;
 		} else {
 			dialling();
 			document.getElementById("info").innerHTML = "CONNECTING";
-
-			// TODO move this logic to wormhole package.
-			let [slot, ...passparts] = document.getElementById("magiccode").value.split("-");
-			let pass = passparts.join("-");
-			console.log("dialling slot", slot, "pass", pass);
-
-			await dial(pc, slot, pass);
+			await dial(pc, document.getElementById("magiccode").value);
 		}
 	} catch (err) {
 		disconnected();
 		if (err == "bad key") {
 			document.getElementById("info").innerHTML = "BAD KEY TRY AGAIN";
+		} else if (err == "no such slot") {
+			document.getElementById("info").innerHTML = "NO SUCH SLOT";
+		} else if (err == "timed out") {
+			document.getElementById("info").innerHTML = "CODE TIMED OUT GENERATE ANOTHER";
 		} else {
 			document.getElementById("info").innerHTML = "COULD NOT CONNECT TRY AGAIN";
 		}

--- a/werkzeuge/Dockerfile
+++ b/werkzeuge/Dockerfile
@@ -11,5 +11,6 @@ RUN go build -o /bin/ww ./cmd/ww
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=build /bin/ww /bin
-COPY --from=build /web /lib/webwormhole/web
+COPY --from=build /web /web
+WORKDIR /
 ENTRYPOINT ["/bin/ww", "server"]

--- a/werkzeuge/linuxkit.yaml
+++ b/werkzeuge/linuxkit.yaml
@@ -24,7 +24,7 @@ services:
     image: webwormhole:latest
     capabilities:
       - CAP_NET_BIND_SERVICE
-    command: ["/bin/ww", "server", "-hosts", "cpacemachine.0f.io,oursink.com,bitfro.st,webwormhole.io,wrmhl.link"]
+    command: ["/bin/ww", "server", "-hosts", "webwormhole.io,wrmhl.link,tip.webwormhole.io,oursink.com,"]
     binds:
       - /etc/resolv.conf:/etc/resolv.conf
   - name: sshd


### PR DESCRIPTION
Websockets make it easier to do trickle ICE, which in turn gives us
a much faster WebRTC handshake. It's also way more reliable with
some browser combinations for reasons that I do not understand.
This is breaking change and once deployed people using the command
line client would need to upgrade.

https://tools.ietf.org/html/draft-ietf-ice-trickle-21

This also adds a bunch more console logging in the web client.

Try it at https://tip.webwormhole.io/ and let me know.