### PR TITLE
adding a autocomplete span under the inputfield

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -17,7 +17,8 @@
 <ul id="transfers"></ul>
 <img id="qr">
 <input type="submit" id="dial" class="button" value="LOADING..." disabled>
-<input type="text" id="magiccode" autocomplete="off" title="WORMHOLE CODE" placeholder="GOT A CODE? TYPE HERE">
+<input type="text" id="magiccode" autocomplete="off" autofocus title="WORMHOLE CODE" placeholder="GOT A CODE? TYPE HERE">
+<span id="autocomplete">&nbsp;</span>
 </form>
 <footer>
 <span>source: <a href="https://github.com/saljam/webwormhole">github.com/saljam/webwormhole</a></span>

--- a/web/main.js
+++ b/web/main.js
@@ -1,4 +1,5 @@
 import { newwormhole, dial } from './dial.js'
+import { autocomplete } from './wordlist.js'
 
 let receiving
 let sending
@@ -477,6 +478,7 @@ const wasmready = async () => {
   // block them.
   window.addEventListener('hashchange', hashchange)
   document.getElementById('magiccode').addEventListener('input', codechange)
+  document.getElementById('magiccode').addEventListener('keydown', autocomplete)
   document.getElementById('filepicker').addEventListener('change', pick)
   document.getElementById('dialog').addEventListener('submit', preventdefault)
   document.getElementById('dialog').addEventListener('submit', connect)

--- a/web/style.css
+++ b/web/style.css
@@ -122,6 +122,10 @@ footer span {
 	display: none;
 }
 
+#autocomplete {
+	font-style: italic;
+}
+
 .button {
 	-webkit-appearance: none;
 	appearance: none;

--- a/web/wordlist.js
+++ b/web/wordlist.js
@@ -18,6 +18,41 @@ export const decode = words => {
   return bytes
 }
 
+var currentHint = "";
+
+export const autocomplete = e => {
+  const input = e.keyCode >= 48 ? (e.target.value + e.key).split("-") : e.target.value.split("-");
+  const lastSegment = input.length > 0 ? input[input.length-1] : ""
+
+  var hintFound = false;
+  for (let i=0; i < wordlist.length; i++) {
+    if (wordlist[i].startsWith(lastSegment)) {
+      currentHint = wordlist[i];
+      hintFound = true;
+      break;
+    }
+  }
+
+  if (hintFound) {
+    document.querySelector("#autocomplete").innerText = currentHint;
+    if (e.keyCode == 9) {
+      if (input.length <= 3) {
+        document.forms.dialog.magiccode.value += currentHint.substring(lastSegment.length);
+        if (input.length <= 2) {
+          document.forms.dialog.magiccode.value += "-";
+        }
+        e.preventDefault();
+        document.querySelector("#autocomplete").innerHTML = "&nbsp;";
+      }
+    }
+  } else {
+    document.querySelector("#autocomplete").innerHTML = "&nbsp;";
+    if (e.keyCode == 9) {
+      e.preventDefault();
+    }
+  }
+}
+
 const wordlist = [
   'aardvark', 'adroitness',
   'absurd', 'adviser',


### PR DESCRIPTION
The PR adds the autocomplete from #47 to the input field by showing a `<span>` underneath the field with the current autocompletion - to be completed by pressing tab. Stop automatically after the code has three parts divided by `-`