### PR TITLE
Adds ability to use envvars other than flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	filippo.io/cpace v0.0.0-20200503185815-340c58da85ed
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/pion/webrtc/v2 v2.2.11
-	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59
+	golang.org/x/crypto v0.0.0-20200602180216-279210d13fed
 	nhooyr.io/websocket v1.8.5
 	rsc.io/qr v0.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	filippo.io/cpace v0.0.0-20200503185815-340c58da85ed
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/pion/webrtc/v2 v2.2.11
-	golang.org/x/crypto v0.0.0-20200602180216-279210d13fed
+	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59
 	nhooyr.io/websocket v1.8.5
 	rsc.io/qr v0.2.0
 )


### PR DESCRIPTION
This should address #44 providing ability to use envvars to specify if
run in verbose mode or use alternative signal server.

The envvars are named respectively `WW_VERBOSE` and `WW_SIGNAL`. As stated
in best practices flags have precedence over envvars.

Helper methods are from
https://www.gmarik.info/blog/2019/12-factor-golang-flag-package/

Some pointer references has been turned to direct references due to
adapt to the `flag.BoolVar()` and `flag.StringVar()` functions.