### PR TITLE
Provide custom certificate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	filippo.io/cpace v0.0.0-20200503185815-340c58da85ed
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/pion/webrtc/v2 v2.2.11
-	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59
+	golang.org/x/crypto v0.0.0-20200602180216-279210d13fed
 	nhooyr.io/websocket v1.8.5
 	rsc.io/qr v0.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	filippo.io/cpace v0.0.0-20200503185815-340c58da85ed
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/pion/webrtc/v2 v2.2.11
-	golang.org/x/crypto v0.0.0-20200602180216-279210d13fed
+	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59
 	nhooyr.io/websocket v1.8.5
 	rsc.io/qr v0.2.0
 )


### PR DESCRIPTION
Adds two new flags for server: `-custom-cert` and `-custom-key` that should point to local PEM encoded certificate and key.
The certificate and key are read from filesystem only the first time using some trivial caching.
Also added some logging for debug purposes.
