### PR TITLE
Adds ability to provide custom certificate

### DIFF
--- a/cmd/ww/server.go
+++ b/cmd/ww/server.go
@@ -79,10 +79,10 @@ var turnServer string
 var stunServers []webrtc.ICEServer
 
 // For custom certificate and key
-var customCertFlag string
-var customKeyFlag string
-var customCert []byte
-var customKey []byte
+var certFlag string
+var certKeyFlag string
+var cert []byte
+var certKey []byte
 var CustomGetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
 
 // freeslot tries to find an available numeric slot, favouring smaller numbers.
@@ -281,20 +281,20 @@ func PickLocalCert(helloInfo *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	// before opening certificate and key from local files checks if they
 	// are already loaded
 	var err error
-	if len(customCert) == 0 || len(customKey) == 0 {
+	if len(cert) == 0 || len(certKey) == 0 {
 		log.Println("No certificate or key loaded, reading from filesystem")
-		customCert, err = ioutil.ReadFile(customCertFlag)
+		cert, err = ioutil.ReadFile(certFlag)
 		if err != nil {
-			log.Printf("Cannot open certificate %s: %s\n", customCertFlag, err)
+			log.Printf("Cannot open certificate %s: %s\n", certFlag, err)
 			return nil, err
 		}
-		customKey, err = ioutil.ReadFile(customKeyFlag)
+		certKey, err = ioutil.ReadFile(certKeyFlag)
 		if err != nil {
-			log.Printf("Cannot open key %s: %s\n", customKeyFlag, err)
+			log.Printf("Cannot open key %s: %s\n", certKeyFlag, err)
 			return nil, err
 		}
 	}
-	cer, err := tls.X509KeyPair(customCert, customKey)
+	cer, err := tls.X509KeyPair(cert, certKey)
 	if err != nil {
 		log.Println(err)
 		return nil, err
@@ -320,8 +320,8 @@ func server(args ...string) {
 	stunservers := set.String("stun", "stun:relay.webwormhole.io", "list of STUN server addresses to tell clients to use")
 	set.StringVar(&turnServer, "turn", "", "TURN server to use for relaying")
 	set.StringVar(&turnSecret, "turn-secret", "", "secret for HMAC-based authentication in TURN server")
-	set.StringVar(&customCertFlag, "custom-cert", "", "Custom TLS certificate")
-	set.StringVar(&customKeyFlag, "custom-key", "", "Custom TLS key")
+	set.StringVar(&certFlag, "cert", "", "Certificate for HTTPS (leave empty to use letsencrypt)")
+	set.StringVar(&certKeyFlag, "key", "", "Certificate key")
 	set.Parse(args[1:])
 
 	if turnServer != "" && turnSecret == "" {

--- a/cmd/ww/server.go
+++ b/cmd/ww/server.go
@@ -374,7 +374,7 @@ func server(args ...string) {
 		HostPolicy: autocert.HostWhitelist(strings.Split(*whitelist, ",")...),
 	}
 
-	if customCertFlag != "" {
+	if certFlag != "" && certKeyFlag != "" {
 		log.Println("Using local certificate and key")
 		CustomGetCertificate = PickLocalCert
 	} else {

--- a/cmd/ww/server.go
+++ b/cmd/ww/server.go
@@ -77,12 +77,6 @@ var turnSecret string
 var turnServer string
 var stunServers []webrtc.ICEServer
 
-// For custom certificate and key
-var certFlag string
-var certKeyFlag string
-var cert []byte
-var certKey []byte
-
 // freeslot tries to find an available numeric slot, favouring smaller numbers.
 // This assume slots is locked.
 func freeslot() (slot string, ok bool) {
@@ -293,8 +287,8 @@ func server(args ...string) {
 	stunservers := set.String("stun", "stun:relay.webwormhole.io", "list of STUN server addresses to tell clients to use")
 	set.StringVar(&turnServer, "turn", "", "TURN server to use for relaying")
 	set.StringVar(&turnSecret, "turn-secret", "", "secret for HMAC-based authentication in TURN server")
-	set.StringVar(&certFlag, "cert", "", "Certificate for HTTPS (leave empty to use letsencrypt)")
-	set.StringVar(&certKeyFlag, "key", "", "Certificate key")
+	cert := set.String("cert", "", "Certificate for HTTPS (leave empty to use letsencrypt)")
+	key := set.String("key", "", "Certificate key")
 	set.Parse(args[1:])
 
 	if turnServer != "" && turnSecret == "" {
@@ -348,7 +342,7 @@ func server(args ...string) {
 	}
 
 	var customGetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
-	if certFlag != "" && certKeyFlag != "" {
+	if *cert != "" && *key != "" {
 		log.Println("Using local certificate and key")
 	} else {
 		log.Println("Generating acme certificate")
@@ -373,7 +367,7 @@ func server(args ...string) {
 
 	if *httpsaddr != "" {
 		srv.Handler = m.HTTPHandler(nil) // Enable redirect to https handler.
-		go func() { log.Fatal(ssrv.ListenAndServeTLS(certFlag, certKeyFlag)) }()
+		go func() { log.Fatal(ssrv.ListenAndServeTLS(*cert, *key)) }()
 	}
 	log.Fatal(srv.ListenAndServe())
 }


### PR DESCRIPTION
Adds two new flags for server: `-custom-cert` and `-custom-key` that should point to local PEM encoded certificate and key.
The certificate and key are read from filesystem only the first time using some trivial caching.
Also added some logging for debug purposes.