### PR TITLE
Add text input as a way of sending data

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -18,7 +18,13 @@
 <form id="main" role="main">
 <p id="info">WebWormhole lets you send files from one computer to another.</p>
 <div id="top">
-Drag and drop, <label id="filepicker-wrap" class="button">OPEN<input type="file" id="filepicker" disabled /></label>, or <input type="button" id="clipboard" class="button" value="PASTE" disabled /> files and text to send.
+    Drag and drop a file
+    <span class="alternative-divider"><span>OR</span></span>
+    <label id="filepicker-wrap" class="button">CHOOSE A FILE<input type="file" id="filepicker" disabled /></label>
+    <span class="alternative-divider"><span>OR</span></span>
+    <input type="button" id="clipboard" class="button" value="PASTE" disabled /> files and text
+    <span class="alternative-divider"><span>OR</span></span>
+    <input type="text" id="text-content" class="text-input" placeholder="Input text"/><input type="button" id="send-text-content" class="button" value="SEND"/>
 </div>
 <ul id="transfers"></ul>
 <div id="prompt">

--- a/web/main.js
+++ b/web/main.js
@@ -33,6 +33,16 @@ function drop(e) {
 	}
 }
 
+async function sendTextContent() {
+	const textInput = document.getElementById("text-content");
+	const text = textInput.value;
+	if (text.length !== 0) {
+		await sendtext(text);
+		// clear the input field after sending
+		textInput.value = "";
+	}
+}
+
 // Handle a paste event from cmd-v/ctl-v.
 function pasteEvent(e) {
 	const files = e.clipboardData.files;
@@ -710,6 +720,7 @@ async function wasmready() {
 	);
 	document.getElementById("filepicker").addEventListener("change", pick);
 	document.getElementById("clipboard").addEventListener("click", pasteClipboard);
+	document.getElementById("send-text-content").addEventListener("click", sendTextContent);
 	document.getElementById("main").addEventListener("submit", preventdefault);
 	document.getElementById("main").addEventListener("submit", connect);
 	document.getElementById("qr").addEventListener("dblclick", copyurl);

--- a/web/style.css
+++ b/web/style.css
@@ -144,6 +144,21 @@ body.connected {
 	display: inline-block;
 }
 
+.alternative-divider {
+	display: block;
+	width: 100%;
+	text-align: center;
+	border-bottom: 1px solid var(--grey-light);
+	line-height: 0.1em;
+	margin: 25px 0;
+}
+
+.alternative-divider span {
+	background: var(--purple);
+	color: var(--grey-light);
+	padding: 0 10px;
+}
+
 #transfers {
 	display: none;
 	list-style-type: none;
@@ -193,7 +208,7 @@ body.connected {
 	display: unset;
 }
 
-#magiccode {
+#magiccode, .text-input {
 	color: var(--yellow);
 	background: var(--yellow-tint);
 	border: 2px solid var(--yellow);


### PR DESCRIPTION
Sometimes I got a long token or url I'd like to transfer to another PC, exactly the use case of webwormhole. But when using the 'paste' button, I thought it to be helpful to be able to edit the content, e.g. to remove whitespace or a part of the url. Until now I was doing this by first pasting the code in an editor, changing it and then pasting it into webwormhole. I thought this could be simplified, so I added a text field as a method of sending data. 
But with the added text input, the methods became quite cluttered, so I made an attempt to provide a better overview of the different options.

Please let me know what you think about it and if I should change it further! 
Below I also included some screenshots of the before and after.

Before:
![image](https://user-images.githubusercontent.com/9639382/125169170-3a5f9f80-e1a9-11eb-833b-d58c85e19353.png)

After:
![image](https://user-images.githubusercontent.com/9639382/125169123-0edcb500-e1a9-11eb-95a2-e9a93e37f481.png)
