### PR TITLE
Fix field names as received from Go

### DIFF
--- a/web/ww.js
+++ b/web/ww.js
@@ -220,17 +220,7 @@ class Wormhole {
         return;
     }
     makePeerConnection(iceServers) {
-        let normalisedICEServers = [];
-        for (let i = 0; i < iceServers.length; i++) {
-            normalisedICEServers.push({
-                urls: iceServers[i].URLs,
-                username: iceServers[i].Username,
-                credential: iceServers[i].Credential,
-            });
-        }
-        const pc = new RTCPeerConnection({
-            iceServers: normalisedICEServers,
-        });
+        const pc = new RTCPeerConnection({ iceServers: iceServers });
         pc.onicecandidate = (e) => {
             if (!this.ws || !this.key || !this.pc) {
                 return;

--- a/web/ww.ts
+++ b/web/ww.ts
@@ -24,7 +24,7 @@ declare class Go {
 
 // The ICEServers JSON as exported from Pion capitalises field names, but
 // JS expects lowercase dictionary entries.
-type GoICEServers = [{ URLs: string[]; Username: string; Credential: string }];
+type GoICEServers = [{ urls: string[]; username: string; credential: string }];
 
 // Error codes from webwormhole/dial.go.
 enum WormholeErrorCodes {
@@ -296,9 +296,9 @@ class Wormhole {
 		let normalisedICEServers = [];
 		for (let i = 0; i < iceServers.length; i++) {
 			normalisedICEServers.push({
-				urls: iceServers[i].URLs,
-				username: iceServers[i].Username,
-				credential: iceServers[i].Credential,
+				urls: iceServers[i].urls,
+				username: iceServers[i].username,
+				credential: iceServers[i].credential,
 			});
 		}
 		const pc = new RTCPeerConnection({

--- a/web/ww.ts
+++ b/web/ww.ts
@@ -22,10 +22,6 @@ declare class Go {
 	run(instance: WebAssembly.Instance): void;
 }
 
-// The ICEServers JSON as exported from Pion capitalises field names, but
-// JS expects lowercase dictionary entries.
-type GoICEServers = [{ urls: string[]; username: string; credential: string }];
-
 // Error codes from webwormhole/dial.go.
 enum WormholeErrorCodes {
 	closeNoSuchSlot = 4000,
@@ -93,7 +89,7 @@ class Wormhole {
 	}
 
 	async statePlayer1(data: string): Promise<State> {
-		const msg: { slot: string; iceServers: GoICEServers } = JSON.parse(data);
+		const msg: { slot: string; iceServers: RTCIceServer[] } = JSON.parse(data);
 
 		console.log("assigned slot:", msg.slot);
 		this.slot = parseInt(msg.slot, 10);
@@ -110,7 +106,7 @@ class Wormhole {
 			return this.fail("panic");
 		}
 
-		const msg: { iceServers: GoICEServers } = JSON.parse(data);
+		const msg: { iceServers: RTCIceServer[] } = JSON.parse(data);
 
 		this.pc = this.makePeerConnection(msg.iceServers);
 		this.callback(this.pc);
@@ -292,18 +288,8 @@ class Wormhole {
 		return;
 	}
 
-	makePeerConnection(iceServers: GoICEServers): RTCPeerConnection {
-		let normalisedICEServers = [];
-		for (let i = 0; i < iceServers.length; i++) {
-			normalisedICEServers.push({
-				urls: iceServers[i].urls,
-				username: iceServers[i].username,
-				credential: iceServers[i].credential,
-			});
-		}
-		const pc = new RTCPeerConnection({
-			iceServers: normalisedICEServers,
-		});
+	makePeerConnection(iceServers: RTCIceServer[]): RTCPeerConnection {
+		const pc = new RTCPeerConnection({ iceServers: iceServers });
 		pc.onicecandidate = (e: RTCPeerConnectionIceEvent) => {
 			if (!this.ws || !this.key || !this.pc) {
 				return;


### PR DESCRIPTION
These fields are marshaled as lowercase: https://github.com/pion/webrtc/blob/13ebcbdf5d95afdc09b93f0457d54f7737c9ad35/iceserver.go#L13-L16

Must have broke since https://github.com/saljam/webwormhole/pull/100, but not 100% sure